### PR TITLE
Fixes idp Dockerfile

### DIFF
--- a/shibboleth-idp-dockerized/Dockerfile
+++ b/shibboleth-idp-dockerized/Dockerfile
@@ -16,8 +16,8 @@ ENV JETTY_HOME=/opt/jetty-home \
 ARG java_version=8.0.121
 ARG zulu_version=8.20.0.5
 ARG java_hash=e5f4b1d997e50ffe4998c68c8ec45403
-ARG jetty_version=9.3.16.v20170120
-ARG jetty_hash=f007648daa13799554a95c5ec31d44deac7e56b8
+ARG jetty_version=9.4.32.v20200930
+ARG jetty_hash=b7925b37e0ab6264bfbdf51a2b9167cb957c46f4
 ARG idp_version=3.2.1
 ARG idp_hash=231d100c81f3039f08782cc46067718b2fedf2d988fccc543250fb1813a2bc20
 ARG dta_hash=2f547074b06952b94c35631398f36746820a7697
@@ -40,7 +40,7 @@ RUN cd / \
 
 # Download Jetty, verify the hash, and install, initialize a new base
 RUN cd / \
-    && wget http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$jetty_version/jetty-distribution-$jetty_version.tar.gz \
+    && wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/$jetty_version/jetty-distribution-$jetty_version.tar.gz \
     && echo "$jetty_hash  jetty-distribution-$jetty_version.tar.gz" | sha1sum -c - \
     && tar -zxvf jetty-distribution-$jetty_version.tar.gz -C /opt \
     && rm jetty-distribution-$jetty_version.tar.gz \
@@ -56,7 +56,7 @@ RUN cd / \
 
 # Download Shibboleth IdP, verify the hash, and install
 RUN cd / \
-    && wget https://shibboleth.net/downloads/identity-provider/$idp_version/shibboleth-identity-provider-$idp_version.tar.gz \
+    && wget  https://shibboleth.net/downloads/identity-provider/archive/$idp_version/shibboleth-identity-provider-$idp_version.tar.gz \
     && echo "$idp_hash  shibboleth-identity-provider-$idp_version.tar.gz" | sha256sum -c - \
     && tar -zxvf  shibboleth-identity-provider-$idp_version.tar.gz -C /opt \
     && rm /shibboleth-identity-provider-$idp_version.tar.gz \

--- a/shibboleth-idp-dockerized/base/shib-jetty-base/etc/jetty-backchannel.xml
+++ b/shibboleth-idp-dockerized/base/shib-jetty-base/etc/jetty-backchannel.xml
@@ -72,7 +72,7 @@
                 <Set name="idleTimeout"><Property name="jetty.ssl.timeout" default="30000"/></Set>
                 <Set name="soLingerTime"><Property name="jetty.ssl.soLingerTime" default="-1"/></Set>
                 <Set name="acceptorPriorityDelta"><Property name="jetty.ssl.acceptorPriorityDelta" default="0"/></Set>
-                <Set name="selectorPriorityDelta"><Property name="jetty.ssl.selectorPriorityDelta" default="0"/></Set>
+
                 <Set name="acceptQueueSize"><Property name="jetty.ssl.acceptQueueSize" default="0"/></Set>
             </New>
         </Arg>

--- a/shibboleth-idp-dockerized/base/shib-jetty-base/start.ini
+++ b/shibboleth-idp-dockerized/base/shib-jetty-base/start.ini
@@ -3,13 +3,13 @@
 --module=deploy
 --module=annotations
 --module=resources
---module=logging
 --module=requestlog
 --module=servlets
 --module=jsp
 --module=jstl
 --module=ext
 --module=plus
+--module=console-capture
 
 # Allows setting Java system properties (-Dname=value)
 # and JVM flags (-X, -XX) in this file

--- a/shibboleth-idp-dockerized/base/shib-jetty-base/start.ini
+++ b/shibboleth-idp-dockerized/base/shib-jetty-base/start.ini
@@ -19,6 +19,16 @@
 # Uncomment if IdP is installed somewhere other than /opt/shibboleth-idp
 #-Didp.home=/opt/shibboleth-idp
 
-# Maximum amount of memory that Jetty may use, at least 512M is recommended
-# This value will be replaced at runtime using the env JAVA_MAX_MEMORY setting.
--XmxJETTY_MAX_HEAP
+# Newer garbage collector that reduces memory needed for larger metadata files
+-XX:+UseG1GC
+
+# Maximum amount of memory that Jetty may use, at least 1.5G is recommended
+# for handling larger (> 25M) metadata files but you will need to test on
+# your particular metadata configuration
+-Xmx1500m
+
+# Prevent blocking for entropy.
+-Djava.security.egd=file:/dev/urandom
+
+# Set Java tmp location
+-Djava.io.tmpdir=tmp

--- a/shibboleth-idp-dockerized/base/shib-jetty-base/webapps/idp.xml
+++ b/shibboleth-idp-dockerized/base/shib-jetty-base/webapps/idp.xml
@@ -1,7 +1,8 @@
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
-  <Set name="war">/opt/shibboleth-idp/webapp/</Set>
+  <Set name="war">/opt/shibboleth-idp/war/idp.war</Set>
   <Set name="contextPath">/idp</Set>
   <Set name="extractWAR">false</Set>
   <Set name="copyWebDir">false</Set>
   <Set name="copyWebInf">true</Set>
+  <Set name="persistTempDirectory">false</Set>
 </Configure>

--- a/shibboleth-idp-dockerized/run.sh
+++ b/shibboleth-idp-dockerized/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 docker run --rm \
            -it \
+           -d \
            -v $(pwd)/ext-conf:/opt/shibboleth-idp-ext-conf \
            -e JETTY_BROWSER_SSL_KEYSTORE_PASSWORD=12345 \
            -e JETTY_BACKCHANNEL_SSL_KEYSTORE_PASSWORD=abcde \


### PR DESCRIPTION
1. Upgrades jetty to a newer version (older version attempts to download unavailable resources)
2. Removes older functionality to get the new version running
3. Adds `-d` to the idp `./run.sh` script

To test, run a successful `build` and `run` of the id